### PR TITLE
Add LICENSE.txt, .dockerignore, and .gitignore examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@
 
 # ignore .git and .cache folders
 .git
+.github
 .cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# This file specifies a set of patterns for files to exclude from the build context in Docker.
+# Full documentation of the file format is available at: https://docs.docker.com/engine/reference/builder/#dockerignore-file
+#
+#
+
+# ignore .git and .cache folders
+.git
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# This file specifies to git sets of patterns of files to exclude from version control. 
+# Full documentation of the file format is available at: https://git-scm.com/docs/gitignore
+#
+# GitHub provides common templates for a variety of programming languages:
+# https://github.com/github/gitignore
+# We recommend starting with the example that corresponds to your project's language.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2021 St. Jude Children's Research Hospital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Following @jsunny23's suggestion to provide a default LICENSE.txt and examples for .dockerignore and .gitignore. 