### PR TITLE
Point cgc action to stjudecloud org

### DIFF
--- a/.github/workflows/cgc.yml
+++ b/.github/workflows/cgc.yml
@@ -19,7 +19,7 @@ jobs:
           mv ${{ env.CWL_PATH }}.new ${{ env.CWL_PATH }}
           cat ${{ env.CWL_PATH }}
       - id: cgcdeploy
-        uses: jordan-rash/cgc-go@v0.1.4
+        uses: stjudecloud/cgc-go@v0.1.4
         with:
           file_location: "${{ env.CWL_PATH }}"
           shortid: "${{ github.repository }}/${{ github.event.repository.name }}"


### PR DESCRIPTION
The CGC deployment action moved from Jordan's personal account to the stjudecloud organization space. This updates that reference in the GitHub action.